### PR TITLE
Feature/turn prevention

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -28,146 +28,127 @@ public:
     Point body[100];  // Mảng lưu trữ tọa độ các đốt của rắn (kích thước tối đa 100)
     int length;       // Độ dài hiện tại của rắn
     int direction;    // Hướng di chuyển hiện tại (0: Phải, 1: Xuống, 2: Trái, 3: Lên)
-    int prevDirection;// Hướng di chuyển trước đó (để tránh quay đầu 180 độ)
+    int prevDirection;// Hướng di chuyển trước đó (để dùng cho Turn Prevention)
 
-    // Hàm khởi tạo (Constructor) - Được gọi khi tạo đối tượng Snake
+    // Hàm khởi tạo (Constructor)
     Snake() {
-        // Khởi tạo giá trị ban đầu cho rắn
-        length = 3;          // Rắn bắt đầu với 3 đốt
-        body[0] = {10, 10};  // Đầu rắn ở vị trí (10, 10)
-        body[1] = {11, 10};  // Đốt thứ 2
-        body[2] = {12, 10};  // Đốt thứ 3 (đuôi)
-        direction = 2;       // Bắt đầu di chuyển sang Trái (2)
-        prevDirection = 2;   // Hướng trước đó cũng là Trái
+        length = 3;
+        body[0] = {10, 10};
+        body[1] = {11, 10};
+        body[2] = {12, 10};
+        direction = 2;     // Bắt đầu đi sang Trái
+        prevDirection = 2; // Hướng trước đó cũng là Trái
     }
 
-    // Phương thức vẽ rắn lên màn hình console
-    // --- ĐÂY LÀ CODE CHO ISSUE Snake::Draw ---
+    // Phương thức vẽ rắn
     void Draw() {
-        // Lặp qua từng đốt của con rắn
         for (int i = 0; i < length; ++i) {
-            // Di chuyển con trỏ đến vị trí của đốt thứ i
             gotoxy(body[i].x, body[i].y);
-            // In ra ký tự đại diện cho đốt rắn (ví dụ: 'O' hoặc '*')
-            // Ở đây dùng 'X' cho đầu và 'o' cho thân để dễ phân biệt (tùy chọn)
             if (i == 0) {
                 cout << "O"; // Đầu rắn
             } else {
                 cout << "o"; // Thân rắn
             }
-            // Hoặc đơn giản là: cout << "X"; cho tất cả các đốt
         }
     }
-    // --- KẾT THÚC CODE CHO ISSUE Snake::Draw ---
 
-    // --- CÁC PHƯƠNG THỨC KHÁC CẦN IMPLEMENT CHO CÁC ISSUE TIẾP THEO ---
-
-    // Phương thức di chuyển rắn (Cần implement)
+    // Phương thức di chuyển rắn
     void Move() {
         // 1. Cập nhật vị trí các đốt thân (từ đuôi lên gần đầu)
-        //    body[i] = body[i-1]
         for (int i = length - 1; i > 0; --i) {
              body[i] = body[i - 1];
         }
 
-        // 2. Cập nhật vị trí đầu rắn dựa vào direction
-        Point newHead = body[0]; // Lấy vị trí đầu hiện tại
+        // 2. Cập nhật vị trí đầu rắn dựa vào direction hiện tại
+        Point head = body[0]; // Lấy vị trí đầu hiện tại (trước khi di chuyển)
         switch (direction) {
-            case 0: // Phải
-                newHead.x++;
-                break;
-            case 1: // Xuống
-                newHead.y++;
-                break;
-            case 2: // Trái
-                newHead.x--;
-                break;
-            case 3: // Lên
-                newHead.y--;
-                break;
+            case 0: head.x++; break; // Phải
+            case 1: head.y++; break; // Xuống
+            case 2: head.x--; break; // Trái
+            case 3: head.y--; break; // Lên
         }
-        body[0] = newHead; // Cập nhật vị trí mới cho đầu rắn
+        body[0] = head; // Cập nhật vị trí mới cho đầu rắn
 
-        // Lưu lại hướng vừa di chuyển
-         prevDirection = direction;
+        // 3. QUAN TRỌNG: Cập nhật prevDirection SAU KHI đã xác định hướng di chuyển cho bước này
+        //    Nó sẽ lưu lại hướng vừa đi (direction) để dùng cho lần kiểm tra input tiếp theo
+        prevDirection = direction;
     }
 
-    // Phương thức tăng độ dài rắn khi ăn mồi (Cần implement)
+    // Phương thức tăng độ dài rắn khi ăn mồi
     void Grow() {
-        // Tăng length lên 1
-        // Vị trí đốt mới sẽ tự động được cập nhật đúng trong lần gọi Move() tiếp theo
-        // vì vòng lặp di chuyển thân sẽ không ghi đè lên đốt cuối cùng cũ nữa.
-        if (length < 100) { // Đảm bảo không vượt quá kích thước mảng
+        if (length < 100) {
             length++;
+            // Đốt mới sẽ tự động được đặt đúng vị trí ở lần gọi Move() tiếp theo
         }
     }
 
-    // Phương thức kiểm tra va chạm (với tường hoặc với thân) (Cần implement)
+    // Phương thức kiểm tra va chạm (với tường hoặc với thân)
     bool CheckCollision(int boardWidth, int boardHeight) {
         Point head = body[0];
-
         // 1. Kiểm tra va chạm với tường
         if (head.x <= 0 || head.x >= boardWidth - 1 || head.y <= 0 || head.y >= boardHeight - 1) {
-            return true; // Va chạm tường
+            return true;
         }
-
         // 2. Kiểm tra va chạm với thân
         for (int i = 1; i < length; ++i) {
             if (head.x == body[i].x && head.y == body[i].y) {
-                return true; // Tự cắn vào thân
+                return true;
             }
         }
-
-        return false; // Không va chạm
+        return false;
     }
 
-    // (Tùy chọn) Phương thức thay đổi hướng đi
+    // --- ĐÂY LÀ CODE CHO ISSUE Turn Prevention ---
+    // Phương thức thay đổi hướng đi, có kiểm tra ngăn quay đầu 180 độ
     void ChangeDirection(int newDirection) {
-         // Chỉ thay đổi hướng nếu không phải là quay đầu 180 độ
-        if (newDirection == 0 && prevDirection != 2) direction = newDirection; // Phải (ko phải đang đi Trái)
-        else if (newDirection == 1 && prevDirection != 3) direction = newDirection; // Xuống (ko phải đang đi Lên)
-        else if (newDirection == 2 && prevDirection != 0) direction = newDirection; // Trái (ko phải đang đi Phải)
-        else if (newDirection == 3 && prevDirection != 1) direction = newDirection; // Lên (ko phải đang đi Xuống)
+        // Chỉ cập nhật 'direction' nếu hướng mới không phải là hướng ngược lại của 'prevDirection'
+
+        // Muốn đi Phải (0) và hướng trước đó KHÔNG PHẢI là Trái (2)
+        if (newDirection == 0 && prevDirection != 2) {
+            direction = newDirection;
+        }
+        // Muốn đi Xuống (1) và hướng trước đó KHÔNG PHẢI là Lên (3)
+        else if (newDirection == 1 && prevDirection != 3) {
+            direction = newDirection;
+        }
+        // Muốn đi Trái (2) và hướng trước đó KHÔNG PHẢI là Phải (0)
+        else if (newDirection == 2 && prevDirection != 0) {
+            direction = newDirection;
+        }
+        // Muốn đi Lên (3) và hướng trước đó KHÔNG PHẢI là Xuống (1)
+        else if (newDirection == 3 && prevDirection != 1) {
+            direction = newDirection;
+        }
+        // Nếu người chơi nhấn phím quay đầu, 'direction' sẽ không thay đổi.
     }
+    // --- KẾT THÚC CODE CHO ISSUE Turn Prevention ---
 
 }; // --- Kết thúc lớp Snake ---
 
 
 // --- Hàm vẽ khung trò chơi ---
 void DrawBoard(int width, int height) {
-    // Vẽ đường viền ngang trên và dưới
     for (int i = 0; i < width; ++i) {
-        gotoxy(i, 0);
-        cout << "=";
-        gotoxy(i, height - 1);
-        cout << "=";
+        gotoxy(i, 0); cout << "=";
+        gotoxy(i, height - 1); cout << "=";
     }
-    // Vẽ đường viền dọc trái và phải
     for (int i = 0; i < height; ++i) {
-        gotoxy(0, i);
-        cout << "|";
-        gotoxy(width - 1, i);
-        cout << "|";
+        gotoxy(0, i); cout << "|";
+        gotoxy(width - 1, i); cout << "|";
     }
-    // Vẽ góc (tùy chọn)
     gotoxy(0, 0); cout << "+";
     gotoxy(width - 1, 0); cout << "+";
     gotoxy(0, height - 1); cout << "+";
     gotoxy(width - 1, height - 1); cout << "+";
 }
-// --- Kết thúc hàm vẽ khung ---
-
 
 // --- Hàm tạo thức ăn cho rắn ---
 Point GenerateFood(int width, int height, const Snake& snake) {
     Point food;
     bool onSnake;
     do {
-        // Tạo tọa độ ngẫu nhiên trong phạm vi bảng (tránh biên)
-        food.x = rand() % (width - 2) + 1;  // Từ 1 đến width - 2
-        food.y = rand() % (height - 2) + 1; // Từ 1 đến height - 2
-
-        // Kiểm tra xem thức ăn có xuất hiện trên thân rắn không
+        food.x = rand() % (width - 2) + 1;
+        food.y = rand() % (height - 2) + 1;
         onSnake = false;
         for (int i = 0; i < snake.length; ++i) {
             if (food.x == snake.body[i].x && food.y == snake.body[i].y) {
@@ -175,66 +156,55 @@ Point GenerateFood(int width, int height, const Snake& snake) {
                 break;
             }
         }
-    } while (onSnake); // Lặp lại nếu thức ăn xuất hiện trên rắn
-
+    } while (onSnake);
     return food;
 }
 
 // --- Hàm vẽ thức ăn ---
 void DrawFood(const Point& food) {
     gotoxy(food.x, food.y);
-    cout << "*"; // Ký tự đại diện cho thức ăn
+    cout << "*";
 }
 
 // --- Hàm chính của chương trình ---
 int main() {
-    srand(time(0)); // Khởi tạo seed cho hàm random
+    srand(time(0));
 
-    // --- Cài đặt trò chơi ---
-    const int gameWidth = 40;  // Chiều rộng màn hình game
-    const int gameHeight = 20; // Chiều cao màn hình game
+    const int gameWidth = 40;
+    const int gameHeight = 20;
     int score = 0;
     bool gameOver = false;
-    int gameSpeed = 500; // Tốc độ game (ms), số nhỏ hơn -> nhanh hơn
+    int gameSpeed = 200;
 
-    Snake mySnake; // Tạo đối tượng rắn
-    Point food = GenerateFood(gameWidth, gameHeight, mySnake); // Tạo vị trí thức ăn đầu tiên
+    Snake mySnake;
+    Point food = GenerateFood(gameWidth, gameHeight, mySnake);
 
-    // Ẩn con trỏ console (tùy chọn, cho đẹp hơn)
     HANDLE out = GetStdHandle(STD_OUTPUT_HANDLE);
     CONSOLE_CURSOR_INFO cursorInfo;
     GetConsoleCursorInfo(out, &cursorInfo);
-    cursorInfo.bVisible = false; // ẩn con trỏ
+    cursorInfo.bVisible = false;
     SetConsoleCursorInfo(out, &cursorInfo);
 
-
-    // --- Vòng lặp chính của game ---
     while (!gameOver) {
         // 1. Xử lý input từ người dùng
-        if (kbhit()) { // Kiểm tra xem có phím nào được nhấn không
-            char key = getch(); // Lấy ký tự phím được nhấn
+        if (kbhit()) {
+            char key = getch();
+            // Gọi ChangeDirection thay vì gán trực tiếp direction
+            // Logic kiểm tra quay đầu đã nằm trong ChangeDirection
             switch (key) {
-                case 'a': // Trái
-                case 'A':
-                case 75: // Mũi tên trái (cho một số hệ thống)
-                    mySnake.ChangeDirection(2);
+                case 'a': case 'A': case 75: // Trái
+                    mySnake.ChangeDirection(2); // <--- Gọi hàm đã sửa
                     break;
-                case 'd': // Phải
-                case 'D':
-                case 77: // Mũi tên phải
-                    mySnake.ChangeDirection(0);
+                case 'd': case 'D': case 77: // Phải
+                    mySnake.ChangeDirection(0); // <--- Gọi hàm đã sửa
                     break;
-                case 'w': // Lên
-                case 'W':
-                case 72: // Mũi tên lên
-                    mySnake.ChangeDirection(3);
+                case 'w': case 'W': case 72: // Lên
+                    mySnake.ChangeDirection(3); // <--- Gọi hàm đã sửa
                     break;
-                case 's': // Xuống
-                case 'S':
-                case 80: // Mũi tên xuống
-                    mySnake.ChangeDirection(1);
+                case 's': case 'S': case 80: // Xuống
+                    mySnake.ChangeDirection(1); // <--- Gọi hàm đã sửa
                     break;
-                case 27: // Phím Esc -> Thoát game
+                case 27: // Esc
                     gameOver = true;
                     break;
             }
@@ -242,16 +212,15 @@ int main() {
 
         // 2. Cập nhật trạng thái game
         if (!gameOver) {
-            mySnake.Move(); // Di chuyển rắn
+            mySnake.Move(); // Di chuyển rắn (bao gồm cập nhật prevDirection bên trong)
 
-             // Kiểm tra ăn mồi
+            // Kiểm tra ăn mồi
             Point head = mySnake.body[0];
             if (head.x == food.x && head.y == food.y) {
-                mySnake.Grow(); // Rắn dài ra
-                score += 10;     // Tăng điểm
-                food = GenerateFood(gameWidth, gameHeight, mySnake); // Tạo thức ăn mới
-                // Có thể tăng tốc độ game ở đây nếu muốn
-                // if (gameSpeed > 50) gameSpeed -= 5;
+                mySnake.Grow();
+                score += 10;
+                food = GenerateFood(gameWidth, gameHeight, mySnake);
+                // if (gameSpeed > 50) gameSpeed -= 5; // Tùy chọn tăng tốc độ
             }
 
             // Kiểm tra va chạm
@@ -260,23 +229,18 @@ int main() {
             }
         }
 
-
         // 3. Vẽ lại màn hình game
-        system("cls"); // Xóa màn hình cũ
-        DrawBoard(gameWidth, gameHeight); // Vẽ lại khung
-        mySnake.Draw(); // Vẽ rắn ở vị trí mới
-        DrawFood(food); // Vẽ thức ăn
-
-        // Hiển thị điểm số
-        gotoxy(gameWidth + 2, 2); // Vị trí hiển thị điểm (bên ngoài khung)
+        system("cls");
+        DrawBoard(gameWidth, gameHeight);
+        mySnake.Draw();
+        DrawFood(food);
+        gotoxy(gameWidth + 2, 2);
         cout << "Score: " << score;
 
-
-        // 4. Tạm dừng để điều khiển tốc độ game
+        // 4. Tạm dừng
         Sleep(gameSpeed);
 
     } // --- Kết thúc vòng lặp game ---
-
 
     // --- Xử lý khi Game Over ---
     system("cls");
@@ -284,12 +248,10 @@ int main() {
     cout << "GAME OVER!";
     gotoxy(gameWidth / 2 - 8, gameHeight / 2 + 1);
     cout << "Your Score: " << score;
-    gotoxy(0, gameHeight); // Đưa con trỏ xuống dòng cuối để tránh ghi đè thông báo
+    gotoxy(0, gameHeight);
 
-    // Hiện lại con trỏ console trước khi kết thúc
-    cursorInfo.bVisible = true;
+    cursorInfo.bVisible = true; // Hiện lại con trỏ
     SetConsoleCursorInfo(out, &cursorInfo);
 
-
-    return 0; // Kết thúc chương trình
+    return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1,111 +1,295 @@
 #include <iostream>
-#include <windows.h>
-#include <cstdlib>
-#include <conio.h>
-#include <ctime>
+#include <windows.h> // Cho gotoxy, Sleep, SetConsoleCursorPosition, GetStdHandle
+#include <cstdlib>   // Cho system("cls"), rand, srand
+#include <conio.h>   // Cho kbhit, getch
+#include <ctime>     // Cho time() để khởi tạo seed cho rand
+
 using namespace std;
 
-// Khai bao cac thu vien co ban va sưa ham Gotoxy
-void gotoxy( int column, int line )
-{
+// Hàm di chuyển con trỏ console đến vị trí (column, line)
+void gotoxy(int column, int line) {
     COORD coord;
     coord.X = column;
     coord.Y = line;
     SetConsoleCursorPosition(
-        GetStdHandle( STD_OUTPUT_HANDLE ),
+        GetStdHandle(STD_OUTPUT_HANDLE),
         coord
     );
 }
-// End Khai bao cac thu vien co ban va sưa ham Gotoxy
-// Chinh sua Struct Point
-struct Point
-{
+
+// Cấu trúc để lưu trữ tọa độ điểm (x, y)
+struct Point {
     int x, y;
 };
-// End Chinh sua Struct Point
- SnakeClass
 
-//Snake Class
-class Snake
-{
-// Bổ sung nội dung tại đây
-
-class CONRAN{
-main
+// --- Lớp Snake ---
+class Snake {
 public:
-    Point body[100];
-    int length;
-    int direction;
-    int prevDirection;
+    Point body[100];  // Mảng lưu trữ tọa độ các đốt của rắn (kích thước tối đa 100)
+    int length;       // Độ dài hiện tại của rắn
+    int direction;    // Hướng di chuyển hiện tại (0: Phải, 1: Xuống, 2: Trái, 3: Lên)
+    int prevDirection;// Hướng di chuyển trước đó (để tránh quay đầu 180 độ)
 
-}
-//End Snake Class
-    struct Point A[100];
-    int DoDai;
-    CONRAN(){
-        DoDai = 3;
-        A[0].x = 10; A[0].y = 10;
-        A[1].x = 11; A[1].y = 10;
-        A[2].x = 12; A[2].y = 10;
+    // Hàm khởi tạo (Constructor) - Được gọi khi tạo đối tượng Snake
+    Snake() {
+        // Khởi tạo giá trị ban đầu cho rắn
+        length = 3;          // Rắn bắt đầu với 3 đốt
+        body[0] = {10, 10};  // Đầu rắn ở vị trí (10, 10)
+        body[1] = {11, 10};  // Đốt thứ 2
+        body[2] = {12, 10};  // Đốt thứ 3 (đuôi)
+        direction = 2;       // Bắt đầu di chuyển sang Trái (2)
+        prevDirection = 2;   // Hướng trước đó cũng là Trái
     }
-    void Ve(){
-        for (int i = 0; i < DoDai; i++){
-            gotoxy(A[i].x,A[i].y);
-            cout<<"X";
+
+    // Phương thức vẽ rắn lên màn hình console
+    // --- ĐÂY LÀ CODE CHO ISSUE Snake::Draw ---
+    void Draw() {
+        // Lặp qua từng đốt của con rắn
+        for (int i = 0; i < length; ++i) {
+            // Di chuyển con trỏ đến vị trí của đốt thứ i
+            gotoxy(body[i].x, body[i].y);
+            // In ra ký tự đại diện cho đốt rắn (ví dụ: 'O' hoặc '*')
+            // Ở đây dùng 'X' cho đầu và 'o' cho thân để dễ phân biệt (tùy chọn)
+            if (i == 0) {
+                cout << "O"; // Đầu rắn
+            } else {
+                cout << "o"; // Thân rắn
+            }
+            // Hoặc đơn giản là: cout << "X"; cho tất cả các đốt
         }
     }
-    void DiChuyen(int Huong){
-        for (int i = DoDai-1; i>0;i--)
-            A[i] = A[i-1];
-        if (Huong==0) A[0].x = A[0].x + 1;
-        if (Huong==1) A[0].y = A[0].y + 1;
-        if (Huong==2) A[0].x = A[0].x - 1;
-        if (Huong==3) A[0].y = A[0].y - 1;
+    // --- KẾT THÚC CODE CHO ISSUE Snake::Draw ---
 
+    // --- CÁC PHƯƠNG THỨC KHÁC CẦN IMPLEMENT CHO CÁC ISSUE TIẾP THEO ---
+
+    // Phương thức di chuyển rắn (Cần implement)
+    void Move() {
+        // 1. Cập nhật vị trí các đốt thân (từ đuôi lên gần đầu)
+        //    body[i] = body[i-1]
+        for (int i = length - 1; i > 0; --i) {
+             body[i] = body[i - 1];
+        }
+
+        // 2. Cập nhật vị trí đầu rắn dựa vào direction
+        Point newHead = body[0]; // Lấy vị trí đầu hiện tại
+        switch (direction) {
+            case 0: // Phải
+                newHead.x++;
+                break;
+            case 1: // Xuống
+                newHead.y++;
+                break;
+            case 2: // Trái
+                newHead.x--;
+                break;
+            case 3: // Lên
+                newHead.y--;
+                break;
+        }
+        body[0] = newHead; // Cập nhật vị trí mới cho đầu rắn
+
+        // Lưu lại hướng vừa di chuyển
+         prevDirection = direction;
     }
-};
-//DrawBoard
-void DrawBoard(int width, int height)
-{
-    for (int i = 0; i < width; ++i)
-    {
+
+    // Phương thức tăng độ dài rắn khi ăn mồi (Cần implement)
+    void Grow() {
+        // Tăng length lên 1
+        // Vị trí đốt mới sẽ tự động được cập nhật đúng trong lần gọi Move() tiếp theo
+        // vì vòng lặp di chuyển thân sẽ không ghi đè lên đốt cuối cùng cũ nữa.
+        if (length < 100) { // Đảm bảo không vượt quá kích thước mảng
+            length++;
+        }
+    }
+
+    // Phương thức kiểm tra va chạm (với tường hoặc với thân) (Cần implement)
+    bool CheckCollision(int boardWidth, int boardHeight) {
+        Point head = body[0];
+
+        // 1. Kiểm tra va chạm với tường
+        if (head.x <= 0 || head.x >= boardWidth - 1 || head.y <= 0 || head.y >= boardHeight - 1) {
+            return true; // Va chạm tường
+        }
+
+        // 2. Kiểm tra va chạm với thân
+        for (int i = 1; i < length; ++i) {
+            if (head.x == body[i].x && head.y == body[i].y) {
+                return true; // Tự cắn vào thân
+            }
+        }
+
+        return false; // Không va chạm
+    }
+
+    // (Tùy chọn) Phương thức thay đổi hướng đi
+    void ChangeDirection(int newDirection) {
+         // Chỉ thay đổi hướng nếu không phải là quay đầu 180 độ
+        if (newDirection == 0 && prevDirection != 2) direction = newDirection; // Phải (ko phải đang đi Trái)
+        else if (newDirection == 1 && prevDirection != 3) direction = newDirection; // Xuống (ko phải đang đi Lên)
+        else if (newDirection == 2 && prevDirection != 0) direction = newDirection; // Trái (ko phải đang đi Phải)
+        else if (newDirection == 3 && prevDirection != 1) direction = newDirection; // Lên (ko phải đang đi Xuống)
+    }
+
+}; // --- Kết thúc lớp Snake ---
+
+
+// --- Hàm vẽ khung trò chơi ---
+void DrawBoard(int width, int height) {
+    // Vẽ đường viền ngang trên và dưới
+    for (int i = 0; i < width; ++i) {
         gotoxy(i, 0);
         cout << "=";
         gotoxy(i, height - 1);
         cout << "=";
     }
-    for (int i = 0; i < height; ++i)
-    {
+    // Vẽ đường viền dọc trái và phải
+    for (int i = 0; i < height; ++i) {
         gotoxy(0, i);
-        cout << "=";
+        cout << "|";
         gotoxy(width - 1, i);
-        cout << "=";
+        cout << "|";
     }
+    // Vẽ góc (tùy chọn)
+    gotoxy(0, 0); cout << "+";
+    gotoxy(width - 1, 0); cout << "+";
+    gotoxy(0, height - 1); cout << "+";
+    gotoxy(width - 1, height - 1); cout << "+";
 }
+// --- Kết thúc hàm vẽ khung ---
 
-//End DrawBoad
-int main()
-{
-    CONRAN r;
-    int Huong = 0;
-    char t;
 
-    while (1){
-        if (kbhit()){
-            t = getch();
-            if (t=='a') Huong = 2;
-            if (t=='w') Huong = 3;
-            if (t=='d') Huong = 0;
-            if (t=='x') Huong = 1;
+// --- Hàm tạo thức ăn cho rắn ---
+Point GenerateFood(int width, int height, const Snake& snake) {
+    Point food;
+    bool onSnake;
+    do {
+        // Tạo tọa độ ngẫu nhiên trong phạm vi bảng (tránh biên)
+        food.x = rand() % (width - 2) + 1;  // Từ 1 đến width - 2
+        food.y = rand() % (height - 2) + 1; // Từ 1 đến height - 2
+
+        // Kiểm tra xem thức ăn có xuất hiện trên thân rắn không
+        onSnake = false;
+        for (int i = 0; i < snake.length; ++i) {
+            if (food.x == snake.body[i].x && food.y == snake.body[i].y) {
+                onSnake = true;
+                break;
+            }
         }
-        system("cls");
-        r.Ve();
-        r.DiChuyen(Huong);
-        Sleep(300);
-    }
+    } while (onSnake); // Lặp lại nếu thức ăn xuất hiện trên rắn
 
-    return 0;
+    return food;
 }
 
+// --- Hàm vẽ thức ăn ---
+void DrawFood(const Point& food) {
+    gotoxy(food.x, food.y);
+    cout << "*"; // Ký tự đại diện cho thức ăn
+}
+
+// --- Hàm chính của chương trình ---
+int main() {
+    srand(time(0)); // Khởi tạo seed cho hàm random
+
+    // --- Cài đặt trò chơi ---
+    const int gameWidth = 40;  // Chiều rộng màn hình game
+    const int gameHeight = 20; // Chiều cao màn hình game
+    int score = 0;
+    bool gameOver = false;
+    int gameSpeed = 500; // Tốc độ game (ms), số nhỏ hơn -> nhanh hơn
+
+    Snake mySnake; // Tạo đối tượng rắn
+    Point food = GenerateFood(gameWidth, gameHeight, mySnake); // Tạo vị trí thức ăn đầu tiên
+
+    // Ẩn con trỏ console (tùy chọn, cho đẹp hơn)
+    HANDLE out = GetStdHandle(STD_OUTPUT_HANDLE);
+    CONSOLE_CURSOR_INFO cursorInfo;
+    GetConsoleCursorInfo(out, &cursorInfo);
+    cursorInfo.bVisible = false; // ẩn con trỏ
+    SetConsoleCursorInfo(out, &cursorInfo);
 
 
+    // --- Vòng lặp chính của game ---
+    while (!gameOver) {
+        // 1. Xử lý input từ người dùng
+        if (kbhit()) { // Kiểm tra xem có phím nào được nhấn không
+            char key = getch(); // Lấy ký tự phím được nhấn
+            switch (key) {
+                case 'a': // Trái
+                case 'A':
+                case 75: // Mũi tên trái (cho một số hệ thống)
+                    mySnake.ChangeDirection(2);
+                    break;
+                case 'd': // Phải
+                case 'D':
+                case 77: // Mũi tên phải
+                    mySnake.ChangeDirection(0);
+                    break;
+                case 'w': // Lên
+                case 'W':
+                case 72: // Mũi tên lên
+                    mySnake.ChangeDirection(3);
+                    break;
+                case 's': // Xuống
+                case 'S':
+                case 80: // Mũi tên xuống
+                    mySnake.ChangeDirection(1);
+                    break;
+                case 27: // Phím Esc -> Thoát game
+                    gameOver = true;
+                    break;
+            }
+        }
+
+        // 2. Cập nhật trạng thái game
+        if (!gameOver) {
+            mySnake.Move(); // Di chuyển rắn
+
+             // Kiểm tra ăn mồi
+            Point head = mySnake.body[0];
+            if (head.x == food.x && head.y == food.y) {
+                mySnake.Grow(); // Rắn dài ra
+                score += 10;     // Tăng điểm
+                food = GenerateFood(gameWidth, gameHeight, mySnake); // Tạo thức ăn mới
+                // Có thể tăng tốc độ game ở đây nếu muốn
+                // if (gameSpeed > 50) gameSpeed -= 5;
+            }
+
+            // Kiểm tra va chạm
+            if (mySnake.CheckCollision(gameWidth, gameHeight)) {
+                 gameOver = true;
+            }
+        }
+
+
+        // 3. Vẽ lại màn hình game
+        system("cls"); // Xóa màn hình cũ
+        DrawBoard(gameWidth, gameHeight); // Vẽ lại khung
+        mySnake.Draw(); // Vẽ rắn ở vị trí mới
+        DrawFood(food); // Vẽ thức ăn
+
+        // Hiển thị điểm số
+        gotoxy(gameWidth + 2, 2); // Vị trí hiển thị điểm (bên ngoài khung)
+        cout << "Score: " << score;
+
+
+        // 4. Tạm dừng để điều khiển tốc độ game
+        Sleep(gameSpeed);
+
+    } // --- Kết thúc vòng lặp game ---
+
+
+    // --- Xử lý khi Game Over ---
+    system("cls");
+    gotoxy(gameWidth / 2 - 5, gameHeight / 2);
+    cout << "GAME OVER!";
+    gotoxy(gameWidth / 2 - 8, gameHeight / 2 + 1);
+    cout << "Your Score: " << score;
+    gotoxy(0, gameHeight); // Đưa con trỏ xuống dòng cuối để tránh ghi đè thông báo
+
+    // Hiện lại con trỏ console trước khi kết thúc
+    cursorInfo.bVisible = true;
+    SetConsoleCursorInfo(out, &cursorInfo);
+
+
+    return 0; // Kết thúc chương trình
+}


### PR DESCRIPTION
Mục đích:
Pull Request này implement logic ngăn chặn người chơi điều khiển rắn quay đầu 180 độ ngay lập tức.

Thay đổi chính:
Sửa đổi phương thức Snake::ChangeDirection(int newDirection): Thêm điều kiện kiểm tra prevDirection trước khi cập nhật direction. Chỉ cho phép đổi hướng nếu hướng mới không phải là hướng ngược lại của prevDirection.
Đảm bảo phương thức Snake::Move() cập nhật prevDirection = direction; sau khi đã di chuyển đầu rắn, để lưu lại hướng vừa đi cho lần kiểm tra input tiếp theo.

Issue liên quan:
Closes #11 

Kiểm thử:
Đã biên dịch và chạy thử trên máy local.
Đã thử nhấn các phím 'w', 'a', 's', 'd' ngược với hướng di chuyển hiện tại, xác nhận rắn không quay đầu 180 độ.

Yêu cầu Review:
Nhờ @UIT24730091
Kiểm tra logic điều kiện trong Snake::ChangeDirection.
Kiểm tra vị trí cập nhật prevDirection trong Snake::Move.
Cảm ơn!